### PR TITLE
Add Docker Compose services

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -37,3 +37,14 @@ trading-platform/
 ```
 
 This skeleton will be expanded with code and infrastructure configurations in later tasks.
+
+## Local development
+
+The `docker-compose.yml` file spins up MongoDB, Zookeeper and Kafka for testing the
+services locally. Start the stack with:
+
+```bash
+docker-compose up -d
+```
+
+MongoDB will be available on `localhost:27017` and Kafka on `localhost:9092`.

--- a/README.md
+++ b/README.md
@@ -37,3 +37,14 @@ trading-platform/
 ```
 
 This skeleton will be expanded with code and infrastructure configurations in later tasks.
+
+## Local development
+
+The `docker-compose.yml` file spins up MongoDB, Zookeeper and Kafka for testing the
+services locally. Start the stack with:
+
+```bash
+docker-compose up -d
+```
+
+MongoDB will be available on `localhost:27017` and Kafka on `localhost:9092`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,35 @@
 version: "3.8"
+
 services:
-  # MongoDB, Kafka and other local dependencies will be configured here
-  # These are placeholders for future setup
   mongodb:
-    image: mongo:latest
+    image: mongo:7
+    container_name: mongodb
     ports:
       - "27017:27017"
+    volumes:
+      - mongo-data:/data/db
+
+  zookeeper:
+    image: bitnami/zookeeper:latest
+    container_name: zookeeper
+    ports:
+      - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+
   kafka:
     image: bitnami/kafka:latest
+    container_name: kafka
     ports:
       - "9092:9092"
+    environment:
+      - KAFKA_BROKER_ID=1
+      - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+    depends_on:
+      - zookeeper
+
+volumes:
+  mongo-data:


### PR DESCRIPTION
## Summary
- configure MongoDB, Kafka and Zookeeper in docker-compose
- document how to start services locally

## Testing
- `mvn -q test`
- `docker-compose -f docker-compose.yml config`

------
https://chatgpt.com/codex/tasks/task_e_684c074bef00832da468cb715849ef03