### PR TITLE
Add observability services

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -48,3 +48,13 @@ docker-compose up -d
 ```
 
 MongoDB will be available on `localhost:27017` and Kafka on `localhost:9092`.
+
+The compose file also starts basic observability tools:
+
+- **Prometheus** reads its configuration from
+  `infrastructure/observability/prometheus/prometheus.yml` and is reachable at
+  `http://localhost:9090`.
+- **Grafana** depends on Prometheus and is exposed on
+  `http://localhost:3000` (default credentials `admin`/`admin`).
+- **Zipkin** provides distributed tracing and listens on
+  `http://localhost:9411`.

--- a/README.md
+++ b/README.md
@@ -48,3 +48,13 @@ docker-compose up -d
 ```
 
 MongoDB will be available on `localhost:27017` and Kafka on `localhost:9092`.
+
+The compose file also starts basic observability tools:
+
+- **Prometheus** reads its configuration from
+  `infrastructure/observability/prometheus/prometheus.yml` and is reachable at
+  `http://localhost:9090`.
+- **Grafana** depends on Prometheus and is exposed on
+  `http://localhost:3000` (default credentials `admin`/`admin`).
+- **Zipkin** provides distributed tracing and listens on
+  `http://localhost:9411`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,5 +31,27 @@ services:
     depends_on:
       - zookeeper
 
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./infrastructure/observability/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: grafana
+    ports:
+      - "3000:3000"
+    depends_on:
+      - prometheus
+
+  zipkin:
+    image: openzipkin/zipkin:latest
+    container_name: zipkin
+    ports:
+      - "9411:9411"
+
 volumes:
   mongo-data:

--- a/infrastructure/observability/prometheus/prometheus.yml
+++ b/infrastructure/observability/prometheus/prometheus.yml
@@ -1,0 +1,7 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'prometheus'
+    static_configs:
+      - targets: ['localhost:9090']


### PR DESCRIPTION
## Summary
- add Prometheus, Grafana and Zipkin containers to docker compose file
- add sample Prometheus config
- document observability stack in README

## Testing
- `apt-get update`
- `apt-get install -y maven`
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_684c088071dc832daa1d3e405be7292a