### PR TITLE
Implement orderbook service with reactive Mongo and Kafka

### DIFF
--- a/services/orderbook-service/pom.xml
+++ b/services/orderbook-service/pom.xml
@@ -24,10 +24,23 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-webflux</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
 
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/KafkaConfig.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/KafkaConfig.java
@@ -1,0 +1,31 @@
+package com.trading.platform.orderbook;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "${spring.kafka.bootstrap-servers:localhost:9092}");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/Order.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/Order.java
@@ -1,0 +1,99 @@
+package com.trading.platform.orderbook;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "orders")
+public class Order {
+    @Id
+    private String id;
+    private String symbol;
+    private BigDecimal price;
+    private int quantity;
+    private int remainingQuantity;
+    private OrderType type;
+    private OrderStatus status;
+    private Instant timestamp;
+
+    public Order() {
+    }
+
+    public Order(String symbol, BigDecimal price, int quantity, OrderType type) {
+        this.symbol = symbol;
+        this.price = price;
+        this.quantity = quantity;
+        this.remainingQuantity = quantity;
+        this.type = type;
+        this.status = OrderStatus.NEW;
+        this.timestamp = Instant.now();
+    }
+
+    // getters and setters
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public BigDecimal getPrice() {
+        return price;
+    }
+
+    public void setPrice(BigDecimal price) {
+        this.price = price;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public int getRemainingQuantity() {
+        return remainingQuantity;
+    }
+
+    public void setRemainingQuantity(int remainingQuantity) {
+        this.remainingQuantity = remainingQuantity;
+    }
+
+    public OrderType getType() {
+        return type;
+    }
+
+    public void setType(OrderType type) {
+        this.type = type;
+    }
+
+    public OrderStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(OrderStatus status) {
+        this.status = status;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderController.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderController.java
@@ -1,0 +1,40 @@
+package com.trading.platform.orderbook;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/orders")
+public class OrderController {
+
+    private final OrderMatchingService service;
+
+    public OrderController(OrderMatchingService service) {
+        this.service = service;
+    }
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public Mono<Order> place(@RequestBody Order order) {
+        return service.placeOrder(order);
+    }
+
+    @GetMapping
+    public Flux<Order> list() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public Mono<Order> get(@PathVariable String id) {
+        return service.getById(id);
+    }
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderMatchingService.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderMatchingService.java
@@ -1,0 +1,80 @@
+package com.trading.platform.orderbook;
+
+import java.util.Comparator;
+
+import org.springframework.stereotype.Service;
+import org.springframework.kafka.core.KafkaTemplate;
+
+import com.trading.platform.orderbook.TradeExecuted;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class OrderMatchingService {
+
+    private final OrderRepository repository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public OrderMatchingService(OrderRepository repository, KafkaTemplate<String, Object> kafkaTemplate) {
+        this.repository = repository;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    public Mono<Order> placeOrder(Order order) {
+        return repository.save(order)
+                .doOnSuccess(o -> kafkaTemplate.send("order.placed", o))
+                .flatMap(this::match)
+                .flatMap(saved -> {
+                    if (saved.getStatus() != OrderStatus.NEW) {
+                        TradeExecuted event = new TradeExecuted(
+                                saved.getType() == OrderType.BUY ? saved.getId() : null,
+                                saved.getType() == OrderType.SELL ? saved.getId() : null,
+                                saved.getQuantity() - saved.getRemainingQuantity());
+                        kafkaTemplate.send("order.matched", event);
+                    }
+                    return repository.save(saved);
+                });
+    }
+
+    private Mono<Order> match(Order placed) {
+        OrderType opposite = placed.getType() == OrderType.BUY ? OrderType.SELL : OrderType.BUY;
+        return repository.findAll()
+                .filter(o -> o.getSymbol().equals(placed.getSymbol()) &&
+                              o.getType() == opposite &&
+                              o.getRemainingQuantity() > 0)
+                .sort(Comparator
+                        .comparing(Order::getPrice, placed.getType() == OrderType.BUY
+                                ? Comparator.naturalOrder()
+                                : Comparator.reverseOrder())
+                        .thenComparing(Order::getTimestamp))
+                .next()
+                .flatMap(match -> executeTrade(placed, match))
+                .switchIfEmpty(Mono.just(placed));
+    }
+
+    private Mono<Order> executeTrade(Order o1, Order o2) {
+        int qty = Math.min(o1.getRemainingQuantity(), o2.getRemainingQuantity());
+        o1.setRemainingQuantity(o1.getRemainingQuantity() - qty);
+        o2.setRemainingQuantity(o2.getRemainingQuantity() - qty);
+        if (o1.getRemainingQuantity() == 0) {
+            o1.setStatus(OrderStatus.FILLED);
+        } else {
+            o1.setStatus(OrderStatus.PARTIALLY_FILLED);
+        }
+        if (o2.getRemainingQuantity() == 0) {
+            o2.setStatus(OrderStatus.FILLED);
+        } else {
+            o2.setStatus(OrderStatus.PARTIALLY_FILLED);
+        }
+        return repository.save(o2).thenReturn(o1);
+    }
+
+    public Flux<Order> getAll() {
+        return repository.findAll();
+    }
+
+    public Mono<Order> getById(String id) {
+        return repository.findById(id);
+    }
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderRepository.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderRepository.java
@@ -1,0 +1,6 @@
+package com.trading.platform.orderbook;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface OrderRepository extends ReactiveMongoRepository<Order, String> {
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderStatus.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderStatus.java
@@ -1,0 +1,7 @@
+package com.trading.platform.orderbook;
+
+public enum OrderStatus {
+    NEW,
+    PARTIALLY_FILLED,
+    FILLED
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderType.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderType.java
@@ -1,0 +1,6 @@
+package com.trading.platform.orderbook;
+
+public enum OrderType {
+    BUY,
+    SELL
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderbookServiceApplication.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/OrderbookServiceApplication.java
@@ -1,0 +1,12 @@
+package com.trading.platform.orderbook;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class OrderbookServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(OrderbookServiceApplication.class, args);
+    }
+}

--- a/services/orderbook-service/src/main/java/com/trading/platform/orderbook/TradeExecuted.java
+++ b/services/orderbook-service/src/main/java/com/trading/platform/orderbook/TradeExecuted.java
@@ -1,0 +1,37 @@
+package com.trading.platform.orderbook;
+
+public class TradeExecuted {
+    private String buyOrderId;
+    private String sellOrderId;
+    private int quantity;
+
+    public TradeExecuted(String buyOrderId, String sellOrderId, int quantity) {
+        this.buyOrderId = buyOrderId;
+        this.sellOrderId = sellOrderId;
+        this.quantity = quantity;
+    }
+
+    public String getBuyOrderId() {
+        return buyOrderId;
+    }
+
+    public void setBuyOrderId(String buyOrderId) {
+        this.buyOrderId = buyOrderId;
+    }
+
+    public String getSellOrderId() {
+        return sellOrderId;
+    }
+
+    public void setSellOrderId(String sellOrderId) {
+        this.sellOrderId = sellOrderId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/services/orderbook-service/src/main/resources/application.yml
+++ b/services/orderbook-service/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/trading
+  kafka:
+    bootstrap-servers: localhost:9092

--- a/services/orderbook-service/src/test/java/com/trading/platform/orderbook/OrderControllerTest.java
+++ b/services/orderbook-service/src/test/java/com/trading/platform/orderbook/OrderControllerTest.java
@@ -1,0 +1,46 @@
+package com.trading.platform.orderbook;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.math.BigDecimal;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import reactor.core.publisher.Mono;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class OrderControllerTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @MockBean
+    OrderRepository repository;
+
+    @MockBean
+    KafkaTemplate<String, Object> kafkaTemplate;
+
+    @Test
+    void placeOrderPublishesEvent() {
+        Order order = new Order("AAPL", BigDecimal.valueOf(10), 5, OrderType.BUY);
+        when(repository.save(order)).thenReturn(Mono.just(order));
+
+        webTestClient.post()
+                .uri("/orders")
+                .contentType(MediaType.APPLICATION_JSON)
+                .bodyValue(order)
+                .exchange()
+                .expectStatus().isCreated();
+
+        verify(kafkaTemplate).send("order.placed", order);
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold `orderbook-service` with Spring Boot WebFlux
- create domain models and MongoDB repository
- add order matching service with Kafka event publishing
- expose REST endpoints
- add integration test for order placement

## Testing
- `mvn test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6855112b16f8832d8208de24773d3f38