### PR TITLE
Add trade service skeleton

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,7 @@
 
     <modules>
         <module>services/orderbook-service</module>
+        <module>services/trade-service</module>
     </modules>
 
     <!-- Modules will be added as the project expands -->

--- a/services/trade-service/pom.xml
+++ b/services/trade-service/pom.xml
@@ -1,0 +1,56 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-starter-parent</artifactId>
+        <version>3.2.4</version>
+        <relativePath/>
+    </parent>
+
+    <groupId>com.trading.platform</groupId>
+    <artifactId>trade-service</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+    <name>trade-service</name>
+    <description>Trade Execution Microservice</description>
+
+    <properties>
+        <java.version>21</java.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-mongodb-reactive</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.kafka</groupId>
+            <artifactId>spring-kafka-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-maven-plugin</artifactId>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/services/trade-service/src/main/java/com/trading/platform/trade/KafkaConfig.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/KafkaConfig.java
@@ -1,0 +1,58 @@
+package com.trading.platform.trade;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+import org.springframework.kafka.support.serializer.JsonSerializer;
+
+@Configuration
+@EnableKafka
+public class KafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, Object> producerFactory() {
+        Map<String, Object> config = new HashMap<>();
+        config.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "${spring.kafka.bootstrap-servers:localhost:9092}");
+        config.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        config.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, JsonSerializer.class);
+        return new DefaultKafkaProducerFactory<>(config);
+    }
+
+    @Bean
+    public KafkaTemplate<String, Object> kafkaTemplate(ProducerFactory<String, Object> pf) {
+        return new KafkaTemplate<>(pf);
+    }
+
+    @Bean
+    public ConsumerFactory<String, Object> consumerFactory() {
+        JsonDeserializer<Object> deserializer = new JsonDeserializer<>();
+        deserializer.addTrustedPackages("*");
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG, "${spring.kafka.bootstrap-servers:localhost:9092}");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, deserializer);
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "trade-service");
+        return new DefaultKafkaConsumerFactory<>(props, new StringDeserializer(), deserializer);
+    }
+
+    @Bean
+    public ConcurrentKafkaListenerContainerFactory<String, Object> kafkaListenerContainerFactory(ConsumerFactory<String, Object> cf) {
+        ConcurrentKafkaListenerContainerFactory<String, Object> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(cf);
+        return factory;
+    }
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/Trade.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/Trade.java
@@ -1,0 +1,66 @@
+package com.trading.platform.trade;
+
+import java.time.Instant;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.mongodb.core.mapping.Document;
+
+@Document(collection = "trades")
+public class Trade {
+    @Id
+    private String id;
+    private String buyOrderId;
+    private String sellOrderId;
+    private int quantity;
+    private Instant timestamp;
+
+    public Trade() {
+    }
+
+    public Trade(String buyOrderId, String sellOrderId, int quantity) {
+        this.buyOrderId = buyOrderId;
+        this.sellOrderId = sellOrderId;
+        this.quantity = quantity;
+        this.timestamp = Instant.now();
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getBuyOrderId() {
+        return buyOrderId;
+    }
+
+    public void setBuyOrderId(String buyOrderId) {
+        this.buyOrderId = buyOrderId;
+    }
+
+    public String getSellOrderId() {
+        return sellOrderId;
+    }
+
+    public void setSellOrderId(String sellOrderId) {
+        this.sellOrderId = sellOrderId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/TradeController.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/TradeController.java
@@ -1,0 +1,30 @@
+package com.trading.platform.trade;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/trades")
+public class TradeController {
+
+    private final TradeService service;
+
+    public TradeController(TradeService service) {
+        this.service = service;
+    }
+
+    @GetMapping
+    public Flux<Trade> list() {
+        return service.getAll();
+    }
+
+    @GetMapping("/{id}")
+    public Mono<Trade> get(@PathVariable String id) {
+        return service.getById(id);
+    }
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/TradeExecuted.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/TradeExecuted.java
@@ -1,0 +1,40 @@
+package com.trading.platform.trade;
+
+public class TradeExecuted {
+    private String buyOrderId;
+    private String sellOrderId;
+    private int quantity;
+
+    public TradeExecuted() {
+    }
+
+    public TradeExecuted(String buyOrderId, String sellOrderId, int quantity) {
+        this.buyOrderId = buyOrderId;
+        this.sellOrderId = sellOrderId;
+        this.quantity = quantity;
+    }
+
+    public String getBuyOrderId() {
+        return buyOrderId;
+    }
+
+    public void setBuyOrderId(String buyOrderId) {
+        this.buyOrderId = buyOrderId;
+    }
+
+    public String getSellOrderId() {
+        return sellOrderId;
+    }
+
+    public void setSellOrderId(String sellOrderId) {
+        this.sellOrderId = sellOrderId;
+    }
+
+    public int getQuantity() {
+        return quantity;
+    }
+
+    public void setQuantity(int quantity) {
+        this.quantity = quantity;
+    }
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/TradeRepository.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/TradeRepository.java
@@ -1,0 +1,6 @@
+package com.trading.platform.trade;
+
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+
+public interface TradeRepository extends ReactiveMongoRepository<Trade, String> {
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/TradeService.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/TradeService.java
@@ -1,0 +1,41 @@
+package com.trading.platform.trade;
+
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Service;
+
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+
+@Service
+public class TradeService {
+
+    private final TradeRepository repository;
+    private final KafkaTemplate<String, Object> kafkaTemplate;
+
+    public TradeService(TradeRepository repository, KafkaTemplate<String, Object> kafkaTemplate) {
+        this.repository = repository;
+        this.kafkaTemplate = kafkaTemplate;
+    }
+
+    @KafkaListener(topics = "order.matched", groupId = "trade-service")
+    public void handleOrderMatched(TradeExecuted event) {
+        Trade trade = new Trade(event.getBuyOrderId(), event.getSellOrderId(), event.getQuantity());
+        repository.save(trade)
+                .doOnSuccess(t -> kafkaTemplate.send("trade.executed", t))
+                .subscribe();
+    }
+
+    @KafkaListener(topics = "trade.executed", groupId = "trade-service-sink")
+    public void handleTradeExecuted(Trade trade) {
+        repository.save(trade).subscribe();
+    }
+
+    public Flux<Trade> getAll() {
+        return repository.findAll();
+    }
+
+    public Mono<Trade> getById(String id) {
+        return repository.findById(id);
+    }
+}

--- a/services/trade-service/src/main/java/com/trading/platform/trade/TradeServiceApplication.java
+++ b/services/trade-service/src/main/java/com/trading/platform/trade/TradeServiceApplication.java
@@ -1,0 +1,14 @@
+package com.trading.platform.trade;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.kafka.annotation.EnableKafka;
+
+@SpringBootApplication
+@EnableKafka
+public class TradeServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(TradeServiceApplication.class, args);
+    }
+}

--- a/services/trade-service/src/main/resources/application.yml
+++ b/services/trade-service/src/main/resources/application.yml
@@ -1,0 +1,6 @@
+spring:
+  data:
+    mongodb:
+      uri: mongodb://localhost:27017/trading
+  kafka:
+    bootstrap-servers: localhost:9092

--- a/services/trade-service/src/test/java/com/trading/platform/trade/TradeControllerTest.java
+++ b/services/trade-service/src/test/java/com/trading/platform/trade/TradeControllerTest.java
@@ -1,0 +1,37 @@
+package com.trading.platform.trade;
+
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.reactive.AutoConfigureWebTestClient;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.web.reactive.server.WebTestClient;
+
+import reactor.core.publisher.Flux;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureWebTestClient
+class TradeControllerTest {
+
+    @Autowired
+    WebTestClient webTestClient;
+
+    @MockBean
+    TradeRepository repository;
+
+    @Test
+    void listTradesReturnsFromRepository() {
+        Trade trade = new Trade("b1", "s1", 10);
+        when(repository.findAll()).thenReturn(Flux.just(trade));
+
+        webTestClient.get()
+                .uri("/trades")
+                .exchange()
+                .expectStatus().isOk()
+                .expectBodyList(Trade.class).isEqualTo(Collections.singletonList(trade));
+    }
+}


### PR DESCRIPTION
## Summary
- scaffold `trade-service` module
- define `Trade` domain model and repository
- set up Kafka config with consumers and producers
- implement `TradeService` with Kafka listeners
- expose `/trades` API via `TradeController`
- include basic test for trade listing
- register trade-service module in root `pom.xml`

## Testing
- `mvn -B verify` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68551a2aa3fc832d9d75bf03f17eee65