### PR TITLE
Implement price feed lambda

### DIFF
--- a/lambdas/price-feed-lambda/pom.xml
+++ b/lambdas/price-feed-lambda/pom.xml
@@ -1,0 +1,72 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.trading.platform</groupId>
+    <artifactId>price-feed-lambda</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+
+    <properties>
+        <maven.compiler.source>21</maven.compiler.source>
+        <maven.compiler.target>21</maven.compiler.target>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-lambda-java-core</artifactId>
+            <version>1.2.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.kafka</groupId>
+            <artifactId>kafka-clients</artifactId>
+            <version>3.7.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.mongodb</groupId>
+            <artifactId>mongodb-driver-sync</artifactId>
+            <version>4.11.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+            <version>2.17.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-api</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.10.0</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.4.1</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/lambdas/price-feed-lambda/src/main/java/com/trading/platform/pricefeed/PriceFeedLambda.java
+++ b/lambdas/price-feed-lambda/src/main/java/com/trading/platform/pricefeed/PriceFeedLambda.java
@@ -1,0 +1,85 @@
+package com.trading.platform.pricefeed;
+
+import java.time.Instant;
+import java.util.Properties;
+import java.util.Random;
+
+import com.amazonaws.services.lambda.runtime.Context;
+import com.amazonaws.services.lambda.runtime.RequestHandler;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+import com.mongodb.client.model.Filters;
+import com.mongodb.client.model.UpdateOptions;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.bson.Document;
+
+public class PriceFeedLambda implements RequestHandler<Object, String> {
+
+    private final KafkaProducer<String, String> producer;
+    private final MongoCollection<Document> collection;
+    private final ObjectMapper mapper = new ObjectMapper();
+    private final Random random = new Random();
+    private final String topic;
+    private final String symbol;
+
+    public PriceFeedLambda() {
+        this(initProducer(), initCollection(),
+                System.getenv().getOrDefault("KAFKA_TOPIC", "market.price"),
+                System.getenv().getOrDefault("SYMBOL", "AAPL"));
+    }
+
+    public PriceFeedLambda(KafkaProducer<String, String> producer,
+                           MongoCollection<Document> collection,
+                           String topic,
+                           String symbol) {
+        this.producer = producer;
+        this.collection = collection;
+        this.topic = topic;
+        this.symbol = symbol;
+    }
+
+    private static KafkaProducer<String, String> initProducer() {
+        String kafka = System.getenv().getOrDefault("KAFKA_BOOTSTRAP_SERVERS", "localhost:9092");
+        Properties props = new Properties();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, kafka);
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+        return new KafkaProducer<>(props);
+    }
+
+    private static MongoCollection<Document> initCollection() {
+        String mongoUri = System.getenv().getOrDefault("MONGODB_URI", "mongodb://localhost:27017");
+        MongoClient client = MongoClients.create(mongoUri);
+        MongoDatabase db = client.getDatabase("trading");
+        return db.getCollection("market_ticks");
+    }
+
+    @Override
+    public String handleRequest(Object input, Context context) {
+        double price = 100 + random.nextDouble() * 10;
+        PriceTick tick = new PriceTick(symbol, price, Instant.now());
+        try {
+            String json = mapper.writeValueAsString(tick);
+            producer.send(new ProducerRecord<>(topic, symbol, json));
+            Document doc = new Document()
+                    .append("_id", symbol)
+                    .append("price", price)
+                    .append("timestamp", tick.getTimestamp());
+            collection.updateOne(Filters.eq("_id", symbol), new Document("$set", doc),
+                    new UpdateOptions().upsert(true));
+            return json;
+        } catch (Exception e) {
+            if (context != null) {
+                context.getLogger().log("Error processing tick: " + e.getMessage());
+            }
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/lambdas/price-feed-lambda/src/main/java/com/trading/platform/pricefeed/PriceTick.java
+++ b/lambdas/price-feed-lambda/src/main/java/com/trading/platform/pricefeed/PriceTick.java
@@ -1,0 +1,42 @@
+package com.trading.platform.pricefeed;
+
+import java.time.Instant;
+
+public class PriceTick {
+    private String symbol;
+    private double price;
+    private Instant timestamp;
+
+    public PriceTick() {
+    }
+
+    public PriceTick(String symbol, double price, Instant timestamp) {
+        this.symbol = symbol;
+        this.price = price;
+        this.timestamp = timestamp;
+    }
+
+    public String getSymbol() {
+        return symbol;
+    }
+
+    public void setSymbol(String symbol) {
+        this.symbol = symbol;
+    }
+
+    public double getPrice() {
+        return price;
+    }
+
+    public void setPrice(double price) {
+        this.price = price;
+    }
+
+    public Instant getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Instant timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/lambdas/price-feed-lambda/src/test/java/com/trading/platform/pricefeed/PriceFeedLambdaTest.java
+++ b/lambdas/price-feed-lambda/src/test/java/com/trading/platform/pricefeed/PriceFeedLambdaTest.java
@@ -1,0 +1,30 @@
+package com.trading.platform.pricefeed;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.model.UpdateOptions;
+
+class PriceFeedLambdaTest {
+
+    @Test
+    void handleRequestPublishesAndStores() {
+        @SuppressWarnings("unchecked")
+        KafkaProducer<String, String> producer = Mockito.mock(KafkaProducer.class);
+        @SuppressWarnings("unchecked")
+        MongoCollection<Document> collection = Mockito.mock(MongoCollection.class);
+        PriceFeedLambda lambda = new PriceFeedLambda(producer, collection, "topic", "AAPL");
+
+        lambda.handleRequest(null, null);
+
+        verify(producer).send(Mockito.any(ProducerRecord.class));
+        verify(collection).updateOne(any(), any(), Mockito.any(UpdateOptions.class));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <module>services/trade-service</module>
         <module>services/portfolio-service</module>
         <module>services/wallet-service</module>
+        <module>lambdas/price-feed-lambda</module>
     </modules>
 
     <!-- Modules will be added as the project expands -->


### PR DESCRIPTION
## Summary
- add `price-feed-lambda` module with Kafka and MongoDB dependencies
- implement `PriceFeedLambda` to generate fake ticks and publish to Kafka while storing latest price in MongoDB
- provide `PriceTick` DTO and unit test
- include lambda module in project aggregator

## Testing
- `mvn -q test` *(fails: Could not resolve dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68553d85ed60832da880c69c0add8187