### PR TITLE
Add observability scaffolding

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ The compose file also starts basic observability tools:
   `infrastructure/observability/prometheus/prometheus.yml` and is reachable at
   `http://localhost:9090`.
 - **Grafana** depends on Prometheus and is exposed on
-  `http://localhost:3000` (default credentials `admin`/`admin`).
+  `http://localhost:3000` (default credentials `admin`/`admin`). It loads
+  dashboards from `infrastructure/observability/grafana/dashboards`.
 - **Zipkin** provides distributed tracing and listens on
   `http://localhost:9411`.
+
+See [docs/observability.md](docs/observability.md) for details on exposing
+Prometheus metrics and customizing Grafana dashboards.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -44,6 +44,9 @@ services:
     container_name: grafana
     ports:
       - "3000:3000"
+    volumes:
+      - ./infrastructure/observability/grafana/provisioning:/etc/grafana/provisioning
+      - ./infrastructure/observability/grafana/dashboards:/etc/grafana/dashboards
     depends_on:
       - prometheus
 

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,47 @@
+# Observability and Monitoring
+
+This project exposes metrics through Prometheus and visualizes them with Grafana.
+
+## Prometheus
+
+Prometheus is configured via `infrastructure/observability/prometheus/prometheus.yml`.
+The configuration scrapes each Spring Boot service on `/actuator/prometheus`.
+
+To enable the endpoint in a service add the following dependency and property to
+that service's build:
+
+```xml
+<dependency>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-actuator</artifactId>
+</dependency>
+<dependency>
+    <groupId>io.micrometer</groupId>
+    <artifactId>micrometer-registry-prometheus</artifactId>
+</dependency>
+```
+
+```properties
+management.endpoints.web.exposure.include=prometheus,health,info
+```
+
+Custom metrics like `orders_placed_total` or `trades_executed_total` can be
+registered using Micrometer:
+
+```java
+@Autowired
+MeterRegistry meterRegistry;
+
+Counter ordersPlaced = Counter.builder("orders_placed_total")
+    .description("Total orders placed")
+    .register(meterRegistry);
+```
+
+## Grafana
+
+Grafana is provisioned automatically when running `docker-compose up`.
+Provisioning files reside in `infrastructure/observability/grafana`.
+Dashboards are loaded from the `dashboards` folder and include views for order
+flow, system health, latency and trading activity.
+
+Access Grafana at <http://localhost:3000> (default `admin`/`admin`).

--- a/infrastructure/observability/grafana/dashboards/latency.json
+++ b/infrastructure/observability/grafana/dashboards/latency.json
@@ -1,0 +1,15 @@
+{
+  "id": null,
+  "title": "Latency",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "HTTP Request Latency",
+      "datasource": "Prometheus",
+      "targets": [ { "expr": "http_server_requests_seconds_sum" } ],
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 }
+    }
+  ],
+  "schemaVersion": 38,
+  "version": 1
+}

--- a/infrastructure/observability/grafana/dashboards/order_flow.json
+++ b/infrastructure/observability/grafana/dashboards/order_flow.json
@@ -1,0 +1,22 @@
+{
+  "id": null,
+  "title": "Order Flow",
+  "panels": [
+    {
+      "type": "stat",
+      "title": "Orders Placed",
+      "datasource": "Prometheus",
+      "targets": [ { "expr": "orders_placed_total" } ],
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 }
+    },
+    {
+      "type": "stat",
+      "title": "Trades Executed",
+      "datasource": "Prometheus",
+      "targets": [ { "expr": "trades_executed_total" } ],
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 }
+    }
+  ],
+  "schemaVersion": 38,
+  "version": 1
+}

--- a/infrastructure/observability/grafana/dashboards/system_health.json
+++ b/infrastructure/observability/grafana/dashboards/system_health.json
@@ -1,0 +1,22 @@
+{
+  "id": null,
+  "title": "System Health",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "CPU Usage",
+      "datasource": "Prometheus",
+      "targets": [ { "expr": "process_cpu_usage" } ],
+      "gridPos": { "x": 0, "y": 0, "w": 12, "h": 8 }
+    },
+    {
+      "type": "graph",
+      "title": "Memory Usage",
+      "datasource": "Prometheus",
+      "targets": [ { "expr": "process_memory_used_bytes" } ],
+      "gridPos": { "x": 12, "y": 0, "w": 12, "h": 8 }
+    }
+  ],
+  "schemaVersion": 38,
+  "version": 1
+}

--- a/infrastructure/observability/grafana/dashboards/trading_activity.json
+++ b/infrastructure/observability/grafana/dashboards/trading_activity.json
@@ -1,0 +1,18 @@
+{
+  "id": null,
+  "title": "Trading Activity",
+  "panels": [
+    {
+      "type": "graph",
+      "title": "Orders vs Trades",
+      "datasource": "Prometheus",
+      "targets": [
+        { "expr": "orders_placed_total", "legendFormat": "orders" },
+        { "expr": "trades_executed_total", "legendFormat": "trades" }
+      ],
+      "gridPos": { "x": 0, "y": 0, "w": 24, "h": 8 }
+    }
+  ],
+  "schemaVersion": 38,
+  "version": 1
+}

--- a/infrastructure/observability/grafana/provisioning/dashboards/dashboard.yml
+++ b/infrastructure/observability/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,8 @@
+apiVersion: 1
+providers:
+  - name: 'Trading Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    options:
+      path: /etc/grafana/dashboards

--- a/infrastructure/observability/grafana/provisioning/datasources/datasource.yml
+++ b/infrastructure/observability/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,7 @@
+apiVersion: 1
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true

--- a/infrastructure/observability/prometheus/prometheus.yml
+++ b/infrastructure/observability/prometheus/prometheus.yml
@@ -5,3 +5,14 @@ scrape_configs:
   - job_name: 'prometheus'
     static_configs:
       - targets: ['localhost:9090']
+
+  # Scrape Spring Boot services for Prometheus metrics
+  - job_name: 'microservices'
+    metrics_path: /actuator/prometheus
+    static_configs:
+      - targets:
+          - orderbook-service:8080
+          - trade-service:8080
+          - wallet-service:8080
+          - portfolio-service:8080
+          - market-feed-service:8080


### PR DESCRIPTION
## Summary
- add Prometheus scrape config for services
- configure Grafana provisioning and example dashboards
- document how to enable metrics and dashboards
- mount Grafana configuration in docker-compose

## Testing
- `mvn -q test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685544e84e6c832d95ea5244cb9a8bdc