### PR TITLE
Add documentation for local setup and APIs

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,3 +58,12 @@ The compose file also starts basic observability tools:
   `http://localhost:3000` (default credentials `admin`/`admin`).
 - **Zipkin** provides distributed tracing and listens on
   `http://localhost:9411`.
+
+## Documentation
+
+Further setup instructions, example API calls and an architecture overview are
+available in the [`docs`](docs) folder:
+
+- [Local Setup](docs/local_setup.md)
+- [API Examples](docs/api_examples.md)
+- [Architecture Diagram](docs/architecture.puml)

--- a/README.md
+++ b/README.md
@@ -58,3 +58,12 @@ The compose file also starts basic observability tools:
   `http://localhost:3000` (default credentials `admin`/`admin`).
 - **Zipkin** provides distributed tracing and listens on
   `http://localhost:9411`.
+
+## Documentation
+
+Further setup instructions, example API calls and an architecture overview are
+available in the [`docs`](docs) folder:
+
+- [Local Setup](docs/local_setup.md)
+- [API Examples](docs/api_examples.md)
+- [Architecture Diagram](docs/architecture.puml)

--- a/docs/api_examples.md
+++ b/docs/api_examples.md
@@ -1,0 +1,48 @@
+# API Examples
+
+The following sample requests assume the services run on `localhost`.
+
+## Orderbook Service
+
+- Place an order:
+  ```bash
+  curl -X POST http://localhost:8080/orders \
+       -H 'Content-Type: application/json' \
+       -d '{"symbol":"AAPL","price":10,"quantity":5,"type":"BUY"}'
+  ```
+- List all orders:
+  ```bash
+  curl http://localhost:8080/orders
+  ```
+
+## Trade Service
+
+- List trades:
+  ```bash
+  curl http://localhost:8080/trades
+  ```
+
+## Wallet Service
+
+- Deposit funds:
+  ```bash
+  curl -X POST http://localhost:8080/wallets/u1/deposit/10
+  ```
+- Withdraw funds:
+  ```bash
+  curl -X POST http://localhost:8080/wallets/u1/withdraw/5
+  ```
+
+## Portfolio Service
+
+- Get user portfolio:
+  ```bash
+  curl http://localhost:8080/portfolios/u1
+  ```
+
+## Test Scenarios
+
+- **Order placement publishes an event** (see `OrderControllerTest`)
+- **Portfolio retrieval returns data from the repository** (`PortfolioControllerTest`)
+- **Trade listing returns trades from the repository** (`TradeControllerTest`)
+- **Wallet deposit updates the balance** (`WalletControllerTest`)

--- a/docs/architecture.puml
+++ b/docs/architecture.puml
@@ -1,0 +1,23 @@
+@startuml
+actor User
+queue Kafka
+Database MongoDB
+
+component OrderbookService
+component WalletService
+component TradeService
+component PortfolioService
+cloud "PriceFeedLambda" as PriceFeed
+
+User --> OrderbookService
+User --> WalletService
+User --> PortfolioService
+OrderbookService --> Kafka : order.placed
+OrderbookService --> MongoDB
+WalletService --> MongoDB
+TradeService --> Kafka : consume order.placed
+TradeService --> MongoDB
+PortfolioService --> MongoDB
+PriceFeed --> Kafka : market.price
+PriceFeed --> MongoDB : latest price
+@enduml

--- a/docs/local_setup.md
+++ b/docs/local_setup.md
@@ -1,0 +1,28 @@
+# Local Setup
+
+This project is a collection of Spring Boot microservices that depend on MongoDB and Kafka. You can run the infrastructure with Docker Compose or use locally installed services.
+
+## Using Docker Compose
+
+1. Install Docker and Docker Compose.
+2. Start the infrastructure containers:
+   ```bash
+   docker-compose up -d
+   ```
+   MongoDB is available on `localhost:27017` and Kafka on `localhost:9092`.
+3. In separate terminals, run each microservice:
+   ```bash
+   cd services/orderbook-service && mvn spring-boot:run
+   cd services/wallet-service && mvn spring-boot:run
+   cd services/trade-service && mvn spring-boot:run
+   cd services/portfolio-service && mvn spring-boot:run
+   ```
+   Each service listens on port `8080` by default. Use `-Dspring-boot.run.arguments=--server.port=<port>` to set a custom port when running multiple services simultaneously.
+
+## Without Docker
+
+1. Install MongoDB and Kafka locally so that they are reachable on the default ports `27017` and `9092`.
+2. Ensure Zookeeper is running for Kafka.
+3. Start the services using Maven as shown above.
+
+The services use the database `trading` and expect a Kafka broker reachable at `localhost:9092`.


### PR DESCRIPTION
## Summary
- document how to run the microservices locally
- add sample API calls and reference tests
- provide a simple PlantUML architecture diagram
- link new docs from the README

## Testing
- `mvn -B verify` *(fails: Could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_685546b757b8832daa816e935ecde2a0